### PR TITLE
fix scale calculations to ensure linear scale change

### DIFF
--- a/Leaflet.DoubleTapDragZoom.js
+++ b/Leaflet.DoubleTapDragZoom.js
@@ -44,7 +44,7 @@ var DoubleTapDragZoom = L.Handler.extend({
 
     var distance = this._startPointY - p.y;
 
-    var scale = Math.pow(Math.E, distance / this._startPointY);
+    var scale = Math.pow(Math.E, distance / 200);
 
     this._zoom = map.getScaleZoom(scale, this._startZoom);
 


### PR DESCRIPTION
Do not rely on starting point - scale change speed should be the same regardless where user started to zoom (top of screen, center or bottom)