### PR TITLE
Fix bug where touch event still propagated

### DIFF
--- a/Leaflet.DoubleTapDragZoom.js
+++ b/Leaflet.DoubleTapDragZoom.js
@@ -10,6 +10,7 @@ var DoubleTapDragZoom = L.Handler.extend({
     this._map.on('doubletapdragstart', this._onDoubleTapDragStart, this);
     this._map.on('doubletapdrag', this._onDoubleTapDrag, this);
     this._map.on('doubletapdragend', this._onDoubleTapDragEnd, this);
+    L.DomEvent.on(this._map._container, 'touchmove', this._onDragging, this);
   },
 
   removeHooks: function () {
@@ -20,7 +21,6 @@ var DoubleTapDragZoom = L.Handler.extend({
 
   _onDoubleTapDragStart: function (e) {
     var map = this._map;
-
     if (!e.touches || e.touches.length !== 1 || map._animatingZoom) { return; }
 
     var p = map.mouseEventToContainerPoint(e.touches[0]);
@@ -39,6 +39,7 @@ var DoubleTapDragZoom = L.Handler.extend({
 
     map._stop();
     map._moveStart(true, false);
+    this._doubleTapDragging = true;
   },
 
   _onDoubleTapDrag: function (e) {
@@ -90,6 +91,14 @@ var DoubleTapDragZoom = L.Handler.extend({
     }
 
     this._center = null;
+    this._doubleTapDragging = false;
+  },
+
+  _onDragging: function (e) {
+    if (this._doubleTapDragging) {
+      L.DomEvent.preventDefault(e);
+      L.DomEvent.stopPropagation(e);
+    }
   }
 });
 


### PR DESCRIPTION
Currently, when the dragging event happens, the `touchmove` event is still propagated which means elements on the map may move with the touch movements rather than the zooming in/out of the map from this library.

Before:
![Animation3](https://user-images.githubusercontent.com/193586/140627711-c00ed488-c469-4721-bcf5-cff68f06e776.gif)


After:
![Animation4](https://user-images.githubusercontent.com/193586/140627492-e7d0ed30-0585-45b4-80b4-ca12989ae6d9.gif)


