### PR TITLE
relax leaflet peer dependency to ^1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "name": "leaflet-doubletapdragzoom",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "leaflet-doubletapdrag": "^0.1.0"
       },
       "peerDependencies": {
-        "leaflet": "~1.0.0"
+        "leaflet": "^1.0.0"
       }
     },
     "node_modules/leaflet": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/cherniavskii/Leaflet.DoubleTapDragZoom.git"
   },
   "peerDependencies": {
-    "leaflet": "~1.0.0"
+    "leaflet": "^1.0.0"
   },
   "keywords": [
     "leaflet",


### PR DESCRIPTION
Following up from https://github.com/cherniavskii/Leaflet.DoubleTapDrag/pull/10 this should make [Leaflet.DoubleTapDragZoom](https://github.com/cherniavskii/Leaflet.DoubleTapDragZoom) work seamlessly with newer versions of leaflet
